### PR TITLE
remove notifications to hush-house channel

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,12 +31,6 @@ resources:
   source:
     url: ((private-slack-hook))
 
-- name: radio-hush-house
-  type: slack
-  source:
-    url: ((hh-slack-hook))
-
-
 jobs:
 - name: welcome-aboard
   plan:
@@ -55,9 +49,6 @@ jobs:
   - put: intercom
     params:
       text_file: message/private.txt
-  - put: radio-hush-house
-    params:
-      text_file: message/wings.txt
 
 - name: crew-change
   plan:


### PR DESCRIPTION
Since hush-house has an interrupt bot, whose configuration is documented in concourse/boarding-pass#18, there is no need to tell the channel who is on call every day. In fact it clutters the discussion!